### PR TITLE
Tooling: Only run TestFlight pipeline on `main`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 steps:
   - label: Build and Upload to TestFlight
+    branches: "main"
     command: .buildkite/commands/build-and-upload-to-testflight.sh
     plugins:
       - automattic/a8c-ci-toolkit#3.4.2


### PR DESCRIPTION
This PR ensures that the TestFlight builds only happen when commits are added to the `main` branch and not on any feature/PR branches. 