### PR TITLE
Add Mac Catalyst build and TestFlight upload in CI

### DIFF
--- a/.buildkite/commands/build-and-upload-to-testflight.sh
+++ b/.buildkite/commands/build-and-upload-to-testflight.sh
@@ -5,8 +5,7 @@ install_gems
 
 echo "--- :node: Installing NPM Dependencies and Syncing Project"
 npm ci
-npm run build
-npx cap sync
+npm run sync
 
 echo "--- :testflight: Build and upload to TestFlight"
 bundle exec fastlane build_and_upload_to_testflight

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,5 +10,6 @@ steps:
     env:
       IMAGE_ID: xcode-15.4
     artifact_paths:
-      - "ios/App/build/Blocknotes.ipa"
-      - "ios/App/build/Blocknotes.app.dSYM.zip"
+      - "build/*.ipa"
+      - "build/*.app.dSYM.zip"
+      - "build/*.pkg"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,5 @@
 steps:
   - label: Build and Upload to TestFlight
-    branches: "main"
     command: .buildkite/commands/build-and-upload-to-testflight.sh
     plugins:
       - automattic/a8c-ci-toolkit#3.4.2

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,11 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
-[*.{yml,yaml}]
+[*.{yml,yaml,rb}]
+indent_style = space
+indent_size = 2
+
+[fastlane/Fastfile]
 indent_style = space
 indent_size = 2
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ node_modules
 fastlane/report.xml
 fastlane/README.md
 /build
+
+# Keep repo neat when building locally
+*.app
+*.app.dSYM.zip
+*.pkg

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,6 @@ node_modules
 /vendor
 fastlane/report.xml
 fastlane/README.md
-/build
 
 # Keep repo neat when building locally
-*.app
-*.app.dSYM.zip
-*.pkg
+/build

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,30 @@
+AllCops:
+  Exclude:
+    - DerivedData/**/*
+    - Pods/**/*
+    - vendor/**/*
+  NewCops: enable
+
+Metrics/BlockLength:
+  # "xfiles" is a standin for `Fast-` and `Pod-` files.
+  Exclude: &xfiles
+    - fastlane/Fastfile
+    - fastlane/**/*.rb
+    - Podfile
+
+Metrics/MethodLength:
+  Max: 30
+  Exclude: *xfiles
+
+Layout/LineLength:
+  Max: 165
+  Exclude: *xfiles
+
+Layout/EmptyLines:
+  Exclude: *xfiles
+
+Style/AsciiComments:
+  Exclude: *xfiles
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,7 +52,22 @@ platform :ios do
       export_options: {
         method: 'app-store',
         provisioningProfiles: {
-          BUNDLE_IDENTIFIER: "match AppStore #{BUNDLE_IDENTIFIER}"
+          BUNDLE_IDENTIFIER => "match AppStore #{BUNDLE_IDENTIFIER}"
+        }
+      },
+      **shared_options
+    )
+    build_app(
+      catalyst_platform: 'macos',
+      destination: 'platform=macOS,arch=x86_64,variant=Mac Catalyst',
+      clean: true,
+      export_options: {
+        # We always used 'app-store' here, but, for Mac Catalyst only?, xcrun logs:
+        #
+        # xcodebuild[96916:64896588] [MT] IDEDistribution: Command line name "app-store" is deprecated. Use "app-store-connect" instead.
+        method: 'app-store-connect',
+        provisioningProfiles: {
+          BUNDLE_IDENTIFIER => "match AppStore #{BUNDLE_IDENTIFIER} catalyst"
         }
       },
       **shared_options
@@ -78,6 +93,10 @@ platform :ios do
 
     sync_code_signing(
       platform: 'ios',
+      **shared_options
+    )
+    sync_code_signing(
+      platform: 'catalyst',
       **shared_options
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,7 +11,13 @@ BUNDLE_IDENTIFIER = 'com.ellavandurpe.blocknotes'
 platform :ios do
   desc 'Builds and uploads Blocknotes to TestFlight'
   lane :build_and_upload_to_testflight do
-    set_up_code_signing
+    build_for_app_store
+    upload_to_testflight(api_key: app_store_connect_api_key)
+  end
+
+  desc 'Builds the app for App Store distribution'
+  lane :build_for_app_store do |options|
+    set_up_code_signing unless options[:skip_code_signing_setup]
 
     latest_build_number = latest_testflight_build_number(
       app_identifier: BUNDLE_IDENTIFIER,
@@ -34,8 +40,6 @@ platform :ios do
         }
       }
     )
-
-    upload_to_testflight(api_key: app_store_connect_api_key)
   end
 
   desc 'Sets up code signing'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,10 +52,12 @@ platform :ios do
 
     upload_to_testflight(
       api_key: api_key,
+      app_platform: 'ios',
       ipa: File.join(OUTPUT_FOLDER, "#{APP_NAME_IOS}.ipa")
     )
     upload_to_testflight(
       api_key: api_key,
+      app_platform: 'osx',
       pkg: File.join(OUTPUT_FOLDER, "#{APP_NAME_MAC_CATALYST}.pkg")
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,6 +11,25 @@ APP_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'ios', 'App')
 
 BUNDLE_IDENTIFIER = 'com.ellavandurpe.blocknotes'
 
+APP_NAME_IOS = 'blocknotes-ios'
+APP_NAME_MAC_CATALYST = 'blocknotes-mac-catalyst'
+
+# Note that we cannot make this a subfolder of APP_FOLDER, or 'npx cap sync' will fail with:
+#
+# ✔ Updating iOS plugins in 1.60ms
+# ✖ Updating iOS native dependencies with bundle exec pod install - failed!
+# ✖ update ios - failed!
+# [error] Command line invocation:
+#         /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project
+#         App.xcodeproj clean
+
+#         User defaults from command line:
+#         IDEPackageSupportUseBuiltinSCM = YES
+
+#         error: Could not delete `<APP_FOLDER>/build`
+#         because it was not created by the build system.
+OUTPUT_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'build')
+
 ENV_FILE_NAME = 'blocknotes.env'
 USER_ENV_FILE_PATH = File.join(Dir.home, '.a8c-apps', ENV_FILE_NAME)
 
@@ -24,31 +43,35 @@ end
 platform :ios do
   desc 'Builds and uploads Blocknotes to TestFlight'
   lane :build_and_upload_to_testflight do
+    require_env_vars!(*ASC_API_KEY_ENV_VARS)
+    api_key = app_store_connect_api_key
+
+    bump_build_number
+
     build_for_app_store
-    upload_to_testflight(api_key: app_store_connect_api_key)
+
+    upload_to_testflight(
+      api_key: api_key,
+      ipa: File.join(OUTPUT_FOLDER, "#{APP_NAME_IOS}.ipa")
+    )
+    upload_to_testflight(
+      api_key: api_key,
+      pkg: File.join(OUTPUT_FOLDER, "#{APP_NAME_MAC_CATALYST}.pkg")
+    )
   end
 
-  desc 'Builds the app for App Store distribution'
+  desc 'Builds the app for iOS and Mac Catalyst App Store distribution'
   lane :build_for_app_store do |options|
     set_up_code_signing unless options[:skip_code_signing_setup]
 
-    latest_build_number = latest_testflight_build_number(
-      app_identifier: BUNDLE_IDENTIFIER,
-      api_key: app_store_connect_api_key
-    )
-
-    increment_build_number(
-      xcodeproj: File.join(APP_FOLDER, 'App.xcodeproj'),
-      build_number: latest_build_number + 1
-    )
-
     shared_options = {
       scheme: 'Blocknotes',
-      workspace: File.join(APP_FOLDER, 'App.xcworkspace')
+      workspace: File.join(APP_FOLDER, 'App.xcworkspace'),
+      output_directory: OUTPUT_FOLDER
     }
 
     build_app(
-      output_directory: File.join(APP_FOLDER, 'build'),
+      output_name: APP_NAME_IOS,
       export_options: {
         method: 'app-store',
         provisioningProfiles: {
@@ -58,14 +81,12 @@ platform :ios do
       **shared_options
     )
     build_app(
+      output_name: APP_NAME_MAC_CATALYST,
       catalyst_platform: 'macos',
       destination: 'platform=macOS,arch=x86_64,variant=Mac Catalyst',
       clean: true,
       export_options: {
-        # We always used 'app-store' here, but, for Mac Catalyst only?, xcrun logs:
-        #
-        # xcodebuild[96916:64896588] [MT] IDEDistribution: Command line name "app-store" is deprecated. Use "app-store-connect" instead.
-        method: 'app-store-connect',
+        method: 'app-store',
         provisioningProfiles: {
           BUNDLE_IDENTIFIER => "match AppStore #{BUNDLE_IDENTIFIER} catalyst"
         }
@@ -103,4 +124,16 @@ platform :ios do
       **shared_options
     )
   end
+end
+
+def bump_build_number
+  latest_build_number = latest_testflight_build_number(
+    app_identifier: BUNDLE_IDENTIFIER,
+    api_key: app_store_connect_api_key
+  )
+
+  increment_build_number(
+    xcodeproj: File.join(APP_FOLDER, 'App.xcodeproj'),
+    build_number: latest_build_number + 1
+  )
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,7 @@ OUTPUT_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'build')
 ENV_FILE_NAME = 'blocknotes.env'
 USER_ENV_FILE_PATH = File.join(Dir.home, '.a8c-apps', ENV_FILE_NAME)
 
-# Notice this import currently needsto be after the USER_ENV_FILE_PATH definition because the const is used by the helpers.
+# Notice this import currently needs to be after the USER_ENV_FILE_PATH definition because the const is used by the helpers.
 import 'lib/helpers.rb'
 
 before_all do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -97,6 +97,9 @@ platform :ios do
     )
     sync_code_signing(
       platform: 'catalyst',
+      # Without this, we'll get:
+      # error: exportArchive: Provisioning profile "match AppStore com.ellavandurpe.blocknotes catalyst" doesn't include signing certificate "3rd Party Mac Developer Installer: Automattic, Inc. (PZYM8XX95Q)".
+      additional_cert_types: 'mac_installer_distribution',
       **shared_options
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'dotenv'
+
 default_platform(:ios)
 
 UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Helper.bundler?
@@ -7,6 +9,16 @@ UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Hel
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 APP_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'ios', 'App')
 BUNDLE_IDENTIFIER = 'com.ellavandurpe.blocknotes'
+
+ENV_FILE_NAME = 'blocknotes.env'
+USER_ENV_FILE_PATH = File.join(Dir.home, '.a8c-apps', ENV_FILE_NAME)
+
+# Notice this import currently needsto be after the USER_ENV_FILE_PATH definition because the const is used by the helpers.
+import 'lib/helpers.rb'
+
+before_all do
+  Dotenv.load(USER_ENV_FILE_PATH)
+end
 
 platform :ios do
   desc 'Builds and uploads Blocknotes to TestFlight'
@@ -44,6 +56,8 @@ platform :ios do
 
   desc 'Sets up code signing'
   lane :set_up_code_signing do |options|
+    require_env_vars!(*ASC_API_KEY_ENV_VARS, *MATCH_ENV_VARS)
+
     setup_ci
 
     sync_code_signing(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,6 +8,7 @@ UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Hel
 
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 APP_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'ios', 'App')
+
 BUNDLE_IDENTIFIER = 'com.ellavandurpe.blocknotes'
 
 ENV_FILE_NAME = 'blocknotes.env'
@@ -41,16 +42,20 @@ platform :ios do
       build_number: latest_build_number + 1
     )
 
-    build_app(
-      workspace: File.join(APP_FOLDER, 'App.xcworkspace'),
-      output_directory: File.join(APP_FOLDER, 'build'),
+    shared_options = {
       scheme: 'Blocknotes',
+      workspace: File.join(APP_FOLDER, 'App.xcworkspace')
+    }
+
+    build_app(
+      output_directory: File.join(APP_FOLDER, 'build'),
       export_options: {
         method: 'app-store',
         provisioningProfiles: {
-          BUNDLE_IDENTIFIER => "match AppStore #{BUNDLE_IDENTIFIER}"
+          BUNDLE_IDENTIFIER: "match AppStore #{BUNDLE_IDENTIFIER}"
         }
-      }
+      },
+      **shared_options
     )
   end
 
@@ -60,15 +65,20 @@ platform :ios do
 
     setup_ci
 
-    sync_code_signing(
+    shared_options = {
       type: 'appstore',
       app_identifier: BUNDLE_IDENTIFIER,
       team_id: 'PZYM8XX95Q',
-      api_key: app_store_connect_api_key,
       storage_mode: 's3',
       s3_region: 'us-east-2',
       s3_bucket: 'a8c-fastlane-match',
-      readonly: options.fetch(:readonly, true)
+      readonly: options.fetch(:readonly, true),
+      api_key: app_store_connect_api_key
+    }
+
+    sync_code_signing(
+      platform: 'ios',
+      **shared_options
     )
   end
 end

--- a/fastlane/example.env
+++ b/fastlane/example.env
@@ -1,0 +1,8 @@
+# You don't need to fill in these values for Fastlane to run.
+#
+# However, if a lane requires some of these environment values and they are not set here, it will fail.
+APP_STORE_CONNECT_API_KEY_KEY_ID=
+APP_STORE_CONNECT_API_KEY_ISSUER_ID=
+APP_STORE_CONNECT_API_KEY_KEY=
+MATCH_S3_ACCESS_KEY=
+MATCH_S3_SECRET_ACCESS_KEY=

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -43,12 +43,3 @@ def get_required_env!(key, env_file_path: USER_ENV_FILE_PATH)
     MSG
   end
 end
-
-def prompt_user_for_app_store_connect_credentials
-  require 'credentials_manager'
-
-  # If Fastlane cannot instantiate a user, it will ask the caller for the email.
-  # Once we have it, we can set it as `FASTLANE_USER` in the environment (which has lifecycle limited to this call) so that the next commands will already have access to it.
-  # Note: if the user is already available to `AccountManager`, setting it in the env is redundant, but Fastlane doesn't provide a way to check it so we have to do it anyway.
-  ENV['FASTLANE_USER'] = CredentialsManager::AccountManager.new.user
-end

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+ASC_API_KEY_ENV_VARS = %w[
+  APP_STORE_CONNECT_API_KEY_KEY_ID
+  APP_STORE_CONNECT_API_KEY_ISSUER_ID
+  APP_STORE_CONNECT_API_KEY_KEY
+].freeze
+
+# Fastlane match also uses MATCH_PASSWORD, but we don't expect it to be set because when running locally folks my want to use the password-in-keychain workflow.
+MATCH_ENV_VARS = %w[
+  MATCH_S3_ACCESS_KEY
+  MATCH_S3_SECRET_ACCESS_KEY
+].freeze
+
+# Use this to ensure all env vars a lane requires are set.
+#
+# The best place to call this is at the start of a lane, to fail early.
+def require_env_vars!(*keys)
+  keys.each { |key| get_required_env!(key) }
+end
+
+# Use this instead of getting values from `ENV` directly. It will throw an error if the requested value is missing.
+def get_required_env!(key, env_file_path: USER_ENV_FILE_PATH)
+  return ENV.fetch(key) if ENV.key?(key)
+
+  message = "Environment variable '#{key}' is not set."
+
+  if is_ci
+    UI.user_error!(message)
+  elsif File.exist?(env_file_path)
+    UI.user_error!("#{message} Consider adding it to #{env_file_path}.")
+  else
+    env_file_example_path = 'fastlane/example.env'
+    env_file_dir = File.dirname(env_file_path)
+    env_file_name = File.basename(env_file_path)
+
+    UI.user_error! <<~MSG
+      #{env_file_name} not found in #{env_file_dir}!
+
+      Please copy #{env_file_example_path} to #{env_file_path} and fill in the values for the automation you require.
+
+      mkdir -p #{env_file_dir} && cp #{env_file_example_path} #{env_file_path}
+    MSG
+  end
+end
+
+def prompt_user_for_app_store_connect_credentials
+  require 'credentials_manager'
+
+  # If Fastlane cannot instantiate a user, it will ask the caller for the email.
+  # Once we have it, we can set it as `FASTLANE_USER` in the environment (which has lifecycle limited to this call) so that the next commands will already have access to it.
+  # Note: if the user is already available to `AccountManager`, setting it in the env is redundant, but Fastlane doesn't provide a way to check it so we have to do it anyway.
+  ENV['FASTLANE_USER'] = CredentialsManager::AccountManager.new.user
+end

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -6,7 +6,7 @@ ASC_API_KEY_ENV_VARS = %w[
   APP_STORE_CONNECT_API_KEY_KEY
 ].freeze
 
-# Fastlane match also uses MATCH_PASSWORD, but we don't expect it to be set because when running locally folks my want to use the password-in-keychain workflow.
+# Fastlane match also uses MATCH_PASSWORD, but we don't expect it to be set because when running locally folks may want to use the password-in-keychain workflow.
 MATCH_ENV_VARS = %w[
   MATCH_S3_ACCESS_KEY
   MATCH_S3_SECRET_ACCESS_KEY

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -364,10 +364,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = PZYM8XX95Q;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PZYM8XX95Q;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -380,6 +382,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.ellavandurpe.blocknotes";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "match AppStore com.ellavandurpe.blocknotes catalyst";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -396,10 +399,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = PZYM8XX95Q;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PZYM8XX95Q;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -411,6 +416,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.ellavandurpe.blocknotes";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "match AppStore com.ellavandurpe.blocknotes catalyst";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;


### PR DESCRIPTION
What is says in the title :)

I manually started a build to test this, so there's no surprises once merging.

Here's screenshot of the CI logs, notice the build number: 9

<img width="1175" alt="image" src="https://github.com/blocknotes-org/blocknotes/assets/1218433/0c6b09bf-0e3d-439d-9722-c4bf5bcea7d7">

_I'm aware of the warnings. They are due to the env or build folder containing both `ipa` and `pkg` after having built them in the same job._

and here's screenshots of the matching build on TestFlight, on both platforms:

<img width="1264" alt="image" src="https://github.com/blocknotes-org/blocknotes/assets/1218433/b16822ad-9215-4901-a91c-9b03f54eb8a6">

<img width="1262" alt="image" src="https://github.com/blocknotes-org/blocknotes/assets/1218433/2432808e-a6f7-4504-8fa0-45b636c9fe35">

