### PR TITLE
Lock down the `CODE_SIGNING_IDENTITY` for iOS dev builds

### DIFF
--- a/ios/App/App/Debug.xcconfig
+++ b/ios/App/App/Debug.xcconfig
@@ -1,6 +1,10 @@
 #include "Base.xcconfig"
 
-CODE_SIGN_IDENTITY = Apple Development
+// Locked to a specific identity rather than the generic "Apple Development"
+// to avoid Xcode resolving to a valid development identity for the
+// DEVELOPMENT_TEAM that is not the one used in the provisioning profile
+// specified below.
+CODE_SIGN_IDENTITY = Apple Development: Created via API (886NX39KP6)
 
 PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*] = match Development com.ellavandurpe.blocknotes
 PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*] = match Development com.ellavandurpe.blocknotes catalyst


### PR DESCRIPTION
This should help resolve issues where Xcode gets confused and selects the wrong identity for development.