### PR TITLE
Use development provisioning profiles managed without Fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -101,15 +101,10 @@ platform :ios do
 
   lane :set_up_code_signing do |readonly: true|
     set_up_code_signing_app_store(readonly: readonly)
-    set_up_code_signing_deveploment(readonly: readonly)
   end
 
   lane :set_up_code_signing_app_store do |readonly: true|
     set_up_code_signing(type: 'appstore', readonly: readonly)
-  end
-
-  lane :set_up_code_signing_deveploment do |readonly: true|
-    set_up_code_signing(type: 'development', readonly: readonly)
   end
 end
 

--- a/ios/App/App/Debug.xcconfig
+++ b/ios/App/App/Debug.xcconfig
@@ -6,5 +6,5 @@
 // specified below.
 CODE_SIGN_IDENTITY = Apple Development: Created via API (886NX39KP6)
 
-PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*] = match Development com.ellavandurpe.blocknotes
-PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*] = match Development com.ellavandurpe.blocknotes catalyst
+PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*] = Blocknotes iOS Development
+PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*] = Blocknotes macOS Catalyst Development


### PR DESCRIPTION
We have internal tooling to manage those in a way that does not require developers to set up Ruby for local every-day work.

Internal refs:

- pdnsEh-1ZG-p2
- https://linear.app/a8c/issue/AINFRA-245

The screenshot below shows Xcode successfully resolving the provisioning profile and development certificate pairs and the app running for Mac Catalyst:

![image](https://github.com/user-attachments/assets/e00fdc88-c4ea-466a-a5a8-9448cee98458)
